### PR TITLE
refactor: Align DTOs with refined schema for validation support

### DIFF
--- a/battletech-editor-app/src/dtos/equipment.dto.ts
+++ b/battletech-editor-app/src/dtos/equipment.dto.ts
@@ -1,0 +1,61 @@
+export interface EquipmentDefinitionDto {
+  equipment_id: number; // PK
+  internal_name: string; // Unique key, e.g., "CLLargePulseLaser"
+  display_name: string;
+  equipment_type: string; // "Weapon", "Ammo", "Misc", "Armor", "InternalStructure", "Engine", "Gyro", "Cockpit", "HeatSink", "JumpJet", "Actuator", etc.
+  tech_base: 'Inner Sphere' | 'Clan' | 'Mixed' | 'All';
+  year_introduced: number;
+  rules_level: string; // "Introductory", "Standard", "Advanced", "Experimental"
+  tonnage: number;
+  critical_slots: number; // Can be 0.5 for some items like Ferro-Fibrous armor
+  cost?: number;
+  battle_value?: number;
+  heat?: number; // For weapons/equipment generating heat
+
+  // Weapon-specific fields
+  damage_short?: string; // e.g., "10", "2d6" (string to accommodate dice notation)
+  damage_medium?: string;
+  damage_long?: string;
+  range_min?: number;
+  range_short?: number;
+  range_medium?: number;
+  range_long?: number;
+  weapon_flags?: string[]; // e.g., ["Pulse", "LBX", "Ultra", "Streak", "DirectFire", "IndirectFire", "Heat"]
+
+  // Ammo-specific fields
+  ammo_per_ton?: number;
+  ammo_rack_size?: number; // e.g., 5 for LRM/5, 1 for AC/10 ammo. Indicates shots per slot/ton for this ammo type.
+  ammo_flags?: string[]; // e.g., ["Explosive", "Inferno", "Tracer"]
+
+  // Misc equipment fields (e.g., CASE, ECM, Targeting Computer)
+  misc_flags?: string[]; // e.g., ["CASE", "TSM", "ECM", "ActiveProbe"]
+
+  // Armor-specific fields
+  armor_points_per_ton?: number; // How many armor points this type of armor provides per ton
+
+  // Structure-specific fields
+  structure_points_per_ton?: number; // How many internal structure points this type of structure provides per ton
+
+  // Variable size fields (for items like Artemis IV, Ferro-Fibrous, etc. that can take half slots or whose size/tonnage can vary)
+  is_variable_size?: boolean; // If true, this equipment can vary in size/tonnage/slots based on unit tonnage or other factors.
+  variable_step_size?: number; // For items that scale, e.g. 0.5 for Ferro taking half-slots.
+
+  // Added for refined validation support
+  /**
+   * Links weapon to compatible ammo types (e.g., "AC10Ammo"),
+   * or ammo to weapon types it feeds (e.g., "AC10").
+   * Used for validation to ensure correct ammo is loaded for weapons.
+   * Can be null if not applicable (e.g. for energy weapons, or general equipment).
+   */
+  ammo_match_key?: string | null;
+  /**
+   * How many units of this specific ammo type this weapon consumes per shot.
+   * Typically 1, but could be more for specific weapon/ammo combinations.
+   * Relevant for weapons; null for non-weapons or ammo itself.
+   */
+  weapon_shot_grouping?: number | null;
+  /** Can this equipment be rear-mounted? (Defaults to false in DB if not specified) */
+  allow_rear_mount?: boolean;
+  /** Can this equipment be turret-mounted? (Defaults to false in DB if not specified, primarily for vehicles) */
+  allow_turret_mount?: boolean;
+}

--- a/battletech-editor-app/src/dtos/force.dto.ts
+++ b/battletech-editor-app/src/dtos/force.dto.ts
@@ -1,0 +1,22 @@
+import { UnitDto } from './unit.dto';
+
+export interface ForceUnitDto {
+  force_unit_id: number; // PK of the force_units table entry (link table or specific force unit record)
+  unit: UnitDto; // The full DTO of the unit.
+  custom_unit_name_in_force?: string; // Custom name or callsign for this unit within this specific force
+  pilot_name?: string; // Name of the pilot assigned to this unit in this force
+  gunnery_skill_override?: number; // Override for the unit's default or crew's gunnery skill
+  piloting_skill_override?: number; // Override for the unit's default or crew's piloting skill
+  unit_role_in_force?: string; // e.g., "Commander", "Scout", "Line Trooper"
+  display_order?: number; // Optional field to control display order in UI lists
+}
+
+export interface ForceDto {
+  force_id: number; // PK
+  force_name: string;
+  faction?: string; // e.g., "Davion", "Kurita", "Clan Wolf"
+  rules_level?: string; // Rules level for the force, could be inherited from units or set force-wide
+  description?: string; // User-provided description for the force
+  user_id?: number; // Optional: If forces are tied to specific users
+  units: ForceUnitDto[]; // Array of units that make up this force
+}

--- a/battletech-editor-app/src/dtos/index.ts
+++ b/battletech-editor-app/src/dtos/index.ts
@@ -1,0 +1,7 @@
+// battletech-editor-app/src/dtos/index.ts
+
+export * from './unit.dto';
+export * from './equipment.dto';
+export * from './mounted-equipment.dto';
+export * from './force.dto';
+export * from './settings.dto';

--- a/battletech-editor-app/src/dtos/mounted-equipment.dto.ts
+++ b/battletech-editor-app/src/dtos/mounted-equipment.dto.ts
@@ -1,0 +1,31 @@
+export interface MountedEquipmentDto {
+  mounted_equipment_id: number; // PK
+  unit_id: number; // FK to UnitDto ID
+  equipment_id: number; // FK to EquipmentDefinitionDto ID
+  equipment_internal_name: string; // Convenience field, from EquipmentDefinitionDto.internal_name
+  equipment_display_name: string; // Convenience field, from EquipmentDefinitionDto.display_name
+  location_id?: number; // FK to UnitLocationDto ID, null if unallocated (e.g. in an OmniPod not yet assigned to a location)
+  location_name?: string; // Convenience field, from UnitLocationDto.location_name, null if unallocated
+  is_rear_mounted?: boolean; // True if equipment is mounted facing rear (e.g. rear laser)
+  is_turret_mounted?: boolean; // True if equipment is in a turret (relevant for vehicles)
+  is_pod_mounted?: boolean; // True if this is part of an OmniPod configuration
+  is_armored_component?: boolean; // True if this component is itself armored (e.g. Armored Engine)
+
+  // Ammo-specific fields
+  current_shots?: number; // Current ammunition count for this specific mounted ammo item
+
+  // Variable size equipment fields
+  variable_size_value?: number; // Actual value for equipment where size can vary (e.g. tons of Ferro-Fibrous)
+
+  // Linked equipment (e.g. Artemis IV linked to an LRM launcher)
+  linked_to_weapon_id?: number; // FK to another MountedEquipmentDto ID (e.g., Artemis IV linked to an LRM)
+
+  // Runtime status fields (useful for UI display during a 'session' or if the DTO represents a unit's current state in a game)
+  is_damaged?: boolean; // Component has taken damage but is not yet destroyed
+  is_destroyed?: boolean; // Component is destroyed and non-functional
+  is_missing?: boolean; // Component is missing (e.g. due to critical hit blowing it off, or pod space not filled)
+  is_jammed?: boolean; // Weapon-specific: weapon is currently jammed
+  is_breached?: boolean; // Component is breached (e.g. CASE breach, engine shielding breach)
+  is_dumping?: boolean; // Ammo-specific: ammo is currently being dumped
+  is_fired_this_turn?: boolean; // Weapon-specific: weapon has been fired this turn
+}

--- a/battletech-editor-app/src/dtos/settings.dto.ts
+++ b/battletech-editor-app/src/dtos/settings.dto.ts
@@ -1,0 +1,40 @@
+export interface ApplicationSettingsDto {
+    // Technology Rules
+    /** If true, technology availability is restricted by year and other tech settings. Corresponds to CConfig.TECH_PROGRESSION */
+    tech_progression_active?: boolean;
+    /** If true, a specific year is used for tech availability rather than a general era. Corresponds to CConfig.TECH_USE_YEAR */
+    tech_use_specific_year?: boolean;
+    /** The specific year used for tech availability if tech_use_specific_year is true. Corresponds to CConfig.TECH_YEAR */
+    tech_current_year?: number;
+    /** If true, technology that is considered "extinct" may still be shown/used. Corresponds to CConfig.TECH_EXTINCT */
+    tech_show_extinct?: boolean;
+    /** If true, unofficial equipment that does not have an introduction year can be used. Corresponds to CConfig.TECH_UNOFFICAL_NO_YEAR */
+    tech_allow_unofficial_without_year?: boolean;
+    /** If true, technology availability is filtered by the selected faction's typical tech. Corresponds to CConfig.TECH_SHOW_FACTION */
+    tech_filter_by_faction?: boolean;
+
+    // Display & Editor Preferences
+    /** If true, the unit summary display uses a TRO-like format. Corresponds to CConfig.MISC_SUMMARY_FORMAT_TRO */
+    display_summary_use_tro_format?: boolean;
+    /** If true, unit quirks are shown in displays. Corresponds to CConfig.RS_SHOW_QUIRKS */
+    display_show_quirks?: boolean;
+    /** If true, the era of the unit is shown in displays. Corresponds to CConfig.RS_SHOW_ERA */
+    display_show_era?: boolean;
+    /** If true, the unit's role is shown in displays. Corresponds to CConfig.RS_SHOW_ROLE */
+    display_show_role?: boolean;
+    /** Determines the type of heat profile to display. Corresponds to CConfig.RS_HEAT_PROFILE */
+    display_heat_profile_type?: 'None' | 'Standard' | 'TacticalOps'; // Example based on common heat display types
+    /** Determines the order in which weapons are listed. Corresponds to CConfig.RS_WEAPONS_ORDER */
+    display_weapons_order?: 'Canon' | 'Location' | 'Heat' | 'Damage' | 'BV'; // Example based on common sorting options
+
+    /** If true, critical slots are automatically filled when equipment is added in the editor. Corresponds to CConfig.MEK_AUTOFILL */
+    editor_autofill_criticals?: boolean;
+    /** If true, critical slots are automatically sorted in the editor. Corresponds to CConfig.MEK_AUTOSORT */
+    editor_autosort_criticals?: boolean;
+    /** If true, critical slots are automatically compacted in the editor. Corresponds to CConfig.MEK_AUTOCOMPACT */
+    editor_autocompact_criticals?: boolean;
+
+    // .mul file handling
+    /** Default action to take when opening a .mul (MegaMek Unit List) file. Corresponds to CConfig.MISC_MUL_OPEN_BEHAVIOUR */
+    mul_default_open_action?: 'ViewForce' | 'EditForce'; // Example: 'ViewForce' might open in a read-only summary, 'EditForce' might open in an editable list.
+}

--- a/battletech-editor-app/src/dtos/unit.dto.ts
+++ b/battletech-editor-app/src/dtos/unit.dto.ts
@@ -1,0 +1,116 @@
+import { MountedEquipmentDto } from './mounted-equipment.dto';
+
+export interface CriticalSlotOccupantDto {
+  mounted_equipment_id: number; // Matches PK of MountedEquipmentDto if it's equipment
+  display_name: string; // Corresponds to equipment_display_name from MountedEquipmentDto or system name
+  type: 'equipment' | 'system'; // To distinguish from fixed systems
+  system_type?: string; // e.g., "Engine", "Gyro", "Actuator", only if type is 'system'
+  is_armored_component?: boolean; // From MountedEquipmentDto or system's property
+  is_damaged?: boolean; // Runtime status for the occupant in this slot
+  is_destroyed?: boolean; // Runtime status for the occupant in this slot
+  is_breached?: boolean; // Runtime status, specific to critical slot damage affecting the occupant
+}
+
+export interface CriticalSlotDto {
+  critical_slot_id: number; // PK
+  slot_index: number;
+  occupant_1?: CriticalSlotOccupantDto;
+  occupant_2?: CriticalSlotOccupantDto;
+  // Slot-specific damage status, if different from occupant status, can be re-added here.
+  // For now, assuming occupant status covers damage relevant to the slot's function.
+}
+
+export interface UnitLocationDto {
+  location_id: number; // PK
+  location_name: string;
+  location_index: number;
+  max_armor_front: number;
+  current_armor_front: number;
+  max_armor_rear?: number;
+  current_armor_rear?: number;
+  max_armor_internal?: number;
+  current_armor_internal?: number;
+  internal_structure_points: number;
+  critical_slots: CriticalSlotDto[]; // Array of critical slots in this location
+
+  // Added for refined armor representation and to reflect DB capabilities
+  /** Indicates if this location type can have rear armor (e.g., torsos can, arms cannot) */
+  can_have_rear_armor?: boolean;
+  /** FK to equipment_definitions for the specific armor material used on this location (if location-specific armor is possible) */
+  armor_equipment_id?: number | null;
+  /** Convenience: Display name of the armor material (e.g., "Standard Armor", "Ferro-Fibrous") */
+  armor_type_name?: string | null;
+  /** Tech base of the armor material, if it can differ from the unit's overall tech base or equipment definition's default */
+  armor_tech_base?: string | null;
+}
+
+export interface UnitQuirkDto {
+  unit_quirk_id: number; // PK
+  quirk_name: string;
+  quirk_description?: string;
+  /**
+   * Type of quirk.
+   * - 'Positive': Beneficial quirk
+   * - 'Negative': Detrimental quirk
+   * - 'BattleMech': Specific to BattleMechs
+   * - 'Vehicle': Specific to Vehicles
+   * - 'BattleArmor': Specific to BattleArmor
+   * - 'Infantry': Specific to Infantry
+   * - 'Aero': Specific to Aerospace units
+   */
+  quirk_type: 'Positive' | 'Negative' | 'BattleMech' | 'Vehicle' | 'BattleArmor' | 'Infantry' | 'Aero' | string;
+  quirk_cost_modifier?: number;
+}
+
+export interface CrewMemberDto {
+  crew_member_id: number; // PK
+  slot_index: number;
+  role: string; // e.g., "Pilot", "Gunner"
+  gunnery_skill?: number;
+  piloting_skill?: number;
+  hits_taken?: number;
+  is_conscious?: boolean;
+}
+
+export interface UnitDto {
+  unit_id: number; // PK
+  name: string;
+  model: string;
+  source_file_content?: string; // Optional for DTO, might be large
+  unit_type: string; // "Mek", "Tank", etc.
+  tonnage: number;
+  battle_value: number;
+  manual_bv?: number;
+  use_manual_bv?: boolean;
+  cost?: number;
+  rules_level: string; // "Introductory", "Standard", etc.
+  tech_base: 'Inner Sphere' | 'Clan' | 'Mixed';
+  year_introduced: number;
+  min_era?: string;
+  max_era?: string;
+  is_omni?: boolean;
+  engine_type_name?: string;
+  engine_rating?: number;
+  gyro_type_name?: string;
+  cockpit_type_name?: string;
+  physical_enhancement_type_name?: string; // e.g., "TSM", "MASC"
+  walk_mp?: number;
+  run_mp?: number; // or cruise for vehicles/aero
+  jump_mp?: number;
+  jump_jet_type_name?: string;
+  base_heat_sinks?: number;
+  heat_sink_type_name?: string;
+  fluff?: string;
+  source_book?: string;
+  image_url?: string;
+  locations: UnitLocationDto[];
+  quirks: UnitQuirkDto[];
+  crew: CrewMemberDto[];
+  unallocated_equipment?: any[]; // Placeholder for unallocated equipment DTOs, ideally list of MountedEquipmentDto
+
+  // Added for aerospace unit support
+  /** Maximum structural integrity points, relevant for aerospace fighters and other applicable units. */
+  structural_integrity_max?: number | null;
+  /** Current structural integrity points. */
+  structural_integrity_current?: number | null;
+}


### PR DESCRIPTION
This commit updates the TypeScript DTOs to reflect the latest refinements made to the database schema. These changes are primarily aimed at providing better data points for implementing unit construction validation logic in the web application's backend.

Key changes include:

- **EquipmentDefinitionDto (`equipment.dto.ts`):**
  - Added `ammo_match_key` for explicit weapon-ammo linking.
  - Added `weapon_shot_grouping` to define ammo consumption per shot.
  - Added `allow_rear_mount` and `allow_turret_mount` boolean flags.

- **UnitDto (`unit.dto.ts`):**
  - Added `structural_integrity_max` and `structural_integrity_current` for aerospace unit support.

- **UnitLocationDto (`unit.dto.ts`):**
  - Added `can_have_rear_armor` to reflect database capability.
  - Added `armor_equipment_id` to link to specific armor material definitions.
  - Added `armor_type_name` (convenience display field).
  - Added `armor_tech_base` for per-location armor tech specification.